### PR TITLE
Function for sending WebSocket Ping command introduced

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,6 +85,13 @@ case .socketDisconnected:
 }
 ```
 
+### Send Ping
+You control for sending WebSocket 'Ping' messages. Full signature is as follows:
+```swift
+func sendPingCommand(data: Data = Data(), completion: (() -> Void)? = nil)
+```
+You will receive 'Pong' message as a response.
+
 
 ## Test Environment
 This example was test with a <b>[Spring Boot](https://spring.io)</b> websocket server with <b>[RabbitMQ](https://www.rabbitmq.com/)</b> as an external message broker.

--- a/SwiftStomp/Classes/SwiftStomp.swift
+++ b/SwiftStomp/Classes/SwiftStomp.swift
@@ -274,6 +274,11 @@ public extension SwiftStomp{
         
         self.sendFrame(frame: StompFrame(name: .abort, headers: headers))
     }
+    
+    func sendPingCommand(data: Data = Data(), completion: (() -> Void)? = nil) {
+        self.socket.write(ping: data, completion: completion)
+    }
+    
 }
 
 /// Helper functions


### PR DESCRIPTION
Hi!
Thanks for the lib!
But here's the problem that prevents me to use it.
SwiftStomp attempts to stop receiving events after some time of idle without any delegate callbacks calls. WebSocket has mechanism to prevent that by Ping-Pong messages. 
I've just add that missed function. I believe it clearly was missed because the WebSocketDelegate already has the implementation for handling 'Pong' messages.  