### PR TITLE
Fixed retain cycles, version number bumped to 1.1.1

### DIFF
--- a/SwiftStomp.podspec
+++ b/SwiftStomp.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = 'SwiftStomp'
-  s.version          = '1.1.0'
+  s.version          = '1.1.1'
   s.summary          = 'An elegant Stomp client for iOS.'
   s.description      = <<-DESC
   SwiftStomp is and elegant, light-weight and easy-to-use STOMP (Simple Text Oriented Messaging Protocol) client for iOS.


### PR DESCRIPTION
While I used your library I discovered that it has multiple retain cycles, which results in memory leak. I fixed them, and created a pull request. I hope you'll find it useful.