### PR TITLE
StarScream compatibility

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "SwiftStomp", targets: ["SwiftStomp"])
     ],
     dependencies: [
-        .package(url: "https://github.com/daltoniam/Starscream.git", .upToNextMinor(from: "4.0.3")),
+        .package(url: "https://github.com/daltoniam/Starscream.git", .upToNextMinor(from: "4.0.6")),
         .package(url: "https://github.com/ashleymills/Reachability.swift", .upToNextMinor(from: "5.0.0"))
     ],
     targets: [

--- a/SwiftStomp/Classes/SwiftStomp.swift
+++ b/SwiftStomp/Classes/SwiftStomp.swift
@@ -523,8 +523,7 @@ fileprivate extension SwiftStomp{
 
 /// Web socket delegate
 extension SwiftStomp : WebSocketDelegate{
-    
-    public func didReceive(event: WebSocketEvent, client: WebSocket) {
+    public func didReceive(event: WebSocketEvent, client: WebSocketClient) {
         switch event {
         case .connected(let headers):
             self.status = .socketConnected
@@ -588,6 +587,10 @@ extension SwiftStomp : WebSocketDelegate{
             if self.autoReconnect{
                 self.scheduleConnector()
             }
+        case .peerClosed:
+            stompLog(type: .info, message: "Socket: Peer closed")
+        @unknown default:
+            stompLog(type: .info, message: "Socket: Unexpected event kind: \(String(describing: event))")
         }
     }
     


### PR DESCRIPTION
Unfortunately the StarScream Team did not follow the rules of semantic versioning (even though they state they are in their Change Log), and introduced compatibility breaking changes following their 4.0.4 release. This made the following changes necessary:
• WebSocketDelegate's didReceive(event:client:) signature was changed (the latter parameter is now a WebSocketClient, not a WebSocket)
• A new WebSocketEvent kind was introduced (peerClosed), now it's handled. To be prepared for future case additions, a new @default handling was added

Since these changes were breaking, the minimum version number of Starscream dependency was increased to 4.0.6.