### PR TITLE
Force library to use Starscream 4.0.6 due to more breaking Starscream changes

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -10,7 +10,7 @@ let package = Package(
         .library(name: "SwiftStomp", targets: ["SwiftStomp"])
     ],
     dependencies: [
-        .package(url: "https://github.com/daltoniam/Starscream.git", .upToNextMinor(from: "4.0.6")),
+        .package(url: "https://github.com/daltoniam/Starscream.git", .exact("4.0.6")),
         .package(url: "https://github.com/ashleymills/Reachability.swift", .upToNextMinor(from: "5.0.0"))
     ],
     targets: [


### PR DESCRIPTION
Starscream have made further breaking changes, this locks SwiftStomp to a specific Starscream release.