### PR TITLE
Remove unexpected newline from start of stomp message body

### DIFF
--- a/SwiftStomp/Classes/SwiftStomp.swift
+++ b/SwiftStomp/Classes/SwiftStomp.swift
@@ -694,7 +694,7 @@ fileprivate class StompFrame<T : RawRepresentable> where T.RawValue == String{
         var lines = frame.components(separatedBy: "\n")
         
         //** Remove first if was empty string
-        if lines.first == ""{
+        if let firstLine = lines.first, firstLine.isEmpty {
             lines.removeFirst()
         }
         
@@ -707,10 +707,11 @@ fileprivate class StompFrame<T : RawRepresentable> where T.RawValue == String{
             throw InvalidStompCommandError()
         }
         
+        //** Remove Command
         lines.removeFirst()
         
         //** Parse Headers
-        while let line = lines.first, line != ""{
+        while let line = lines.first, !line.isEmpty {
             let headerParts = line.components(separatedBy: ":")
             
             if headerParts.count != 2{
@@ -721,7 +722,12 @@ fileprivate class StompFrame<T : RawRepresentable> where T.RawValue == String{
             
             lines.removeFirst()
         }
-        
+
+        //** Remove the blank line between the headers and body
+        if let firstLine = lines.first, firstLine.isEmpty {
+            lines.removeFirst()
+        }
+
         //** Parse body
         var body = lines.joined(separator: "\n")
         


### PR DESCRIPTION
This change ensures a 1:1 between strings sent to a topic and those received. Previously the blank line between the STOMP message header and body section was being included in the body of the message in the `onMessageReceived` delegate callback.