### PR TITLE
Replace starscream with iOS 13+ URLSessionWebSocketTask

### DIFF
--- a/Example/Pods/Local Podspecs/SwiftStomp.podspec.json
+++ b/Example/Pods/Local Podspecs/SwiftStomp.podspec.json
@@ -2,7 +2,7 @@
   "name": "SwiftStomp",
   "version": "0.1.0",
   "summary": "An elegant Stomp client for iOS.",
-  "description": "SwiftStomp is and elegant, light-weight and easy-to-use STOMP (Simple Text Oriented Messaging Protocol) client for iOS.\nIt's based on Starscream, an amazing Websocket library for swift.",
+  "description": "SwiftStomp is and elegant, light-weight and easy-to-use STOMP (Simple Text Oriented Messaging Protocol) client for iOS.\nIt's based on URLSessionWebSocketTask.",
   "homepage": "https://github.com/Romixery/SwiftStomp",
   "license": {
     "type": "MIT License",
@@ -21,9 +21,6 @@
   "swift_versions": "5.0",
   "source_files": "SwiftStomp/Classes/**/*",
   "dependencies": {
-    "Starscream": [
-      "~> 4.0.0"
-    ]
   },
   "swift_version": "5.0"
 }

--- a/Package.swift
+++ b/Package.swift
@@ -1,25 +1,24 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
     name: "SwiftStomp",
     platforms: [
-        .iOS(.v10)
+        .iOS(.v13),
     ],
     products: [
         .library(name: "SwiftStomp", targets: ["SwiftStomp"])
     ],
     dependencies: [
-        .package(url: "https://github.com/daltoniam/Starscream.git", .exact("4.0.6")),
         .package(url: "https://github.com/ashleymills/Reachability.swift", .upToNextMinor(from: "5.0.0"))
     ],
     targets: [
         .target(
             name: "SwiftStomp",
-            dependencies: ["Starscream",
-                           "Reachability"],
+            dependencies: [
+                .product(name: "Reachability", package: "Reachability.swift"),
+            ],
             path: "SwiftStomp"
         )
     ]
 )
-

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # SwiftStomp
 
-## An elegent Stomp client for swift, Base on [Starscream](https://github.com/daltoniam/Starscream) websocket library.
+## An elegent Stomp client for swift, based on iOS URLSessionWebSocketTask.
 
 <!-- [![CI Status](https://img.shields.io/travis/Romixery/SwiftStomp.svg?style=flat)](https://travis-ci.org/Romixery/SwiftStomp) -->
 [![Version](https://img.shields.io/cocoapods/v/SwiftStomp.svg?style=flat)](https://cocoapods.org/pods/SwiftStomp)

--- a/SwiftStomp.podspec
+++ b/SwiftStomp.podspec
@@ -34,6 +34,5 @@ Pod::Spec.new do |s|
   # }
 
   # s.public_header_files = 'Pod/Classes/**/*.h'
-  s.dependency 'Starscream', '~> 4.0.4'
   s.dependency 'ReachabilitySwift', '~> 5.0.0'
 end

--- a/SwiftStomp/Classes/SwiftStomp.swift
+++ b/SwiftStomp/Classes/SwiftStomp.swift
@@ -7,10 +7,10 @@
 //
 
 import Foundation
-import Starscream
+import OSLog
 import Reachability
 
-fileprivate let NULL_CHAR = String(format: "%C", arguments: [0x00])
+fileprivate let NULL_CHAR = "\u{00}"
 
 // MARK: - Enums
 public enum StompRequestFrame : String {
@@ -88,26 +88,29 @@ fileprivate enum StompLogType : String{
 }
 
 // MARK: - SwiftStomp
-public class SwiftStomp{
-    
+public class SwiftStomp: NSObject {
+
     fileprivate var host : URL
     fileprivate var httpConnectionHeaders : [String : String]?
     fileprivate var stompConnectionHeaders : [String : String]?
-    fileprivate var socket : WebSocket!
+
+    fileprivate var urlSession: URLSession?
+    fileprivate var webSocketTask: URLSessionWebSocketTask?
+
     fileprivate var acceptVersion = "1.1,1.2"
     fileprivate var status : StompConnectionStatus = .socketDisconnected
     fileprivate var reconnectScheduler : Timer?
     fileprivate var reconnectTryCount = 0
-    fileprivate var reachability : Reachability!
+    fileprivate var reachability : Reachability?
     fileprivate var hostIsReachabile = true
-    
+
     /// Auto ping peroperties
     fileprivate var pingTimer : Timer?
     fileprivate var pingInterval: TimeInterval = 10 //< 10 Seconds
     fileprivate var autoPingEnabled = false
-    
-    /// It's not a weak delegate - please make sure you avoid retain cycles!
-    public var delegate : SwiftStompDelegate? // WARNING - It's not a weak delegate!
+
+    public weak var delegate: SwiftStompDelegate?
+
     public var enableLogging = false
     public var isConnected : Bool {
         return self.status == .fullyConnected
@@ -115,29 +118,50 @@ public class SwiftStomp{
     public var connectionStatus : StompConnectionStatus{
         return self.status
     }
-    public var callbacksThread : DispatchQueue?
+
+    // Private storage for the callbacksThread, not directly accessible outside of this class
+    private var _callbacksThread: DispatchQueue?
+
+    // Public computed property
+    public var callbacksThread: DispatchQueue {
+        // Getter returns _callbacksThread if it's not nil, otherwise returns DispatchQueue.main
+        get {
+            return _callbacksThread ?? DispatchQueue.main
+        }
+        // Setter allows external code to set _callbacksThread
+        set {
+            _callbacksThread = newValue
+        }
+    }
+
     public var autoReconnect = false
-    
+
     public init (host : URL, headers : [String : String]? = nil, httpConnectionHeaders : [String : String]? = nil){
         self.host = host
-        
-        
         self.stompConnectionHeaders = headers
         self.httpConnectionHeaders = httpConnectionHeaders
-        /// Configure reachability
+        super.init()
+        self.urlSession = URLSession(configuration: .default, delegate: self, delegateQueue: nil)
         self.initReachability()
     }
-    
+
+    deinit {
+        disconnect(force: true)
+    }
+
     private func initReachability(){
-        
-        reachability = try! Reachability(queueQoS: .utility, targetQueue: DispatchQueue(label: "swiftStomp.reachability"), notificationQueue: .global())
-        reachability.whenReachable = { [weak self] _ in
-            self?.stompLog(type: .info, message: "Network IS reachable")
-            self?.hostIsReachabile = true
-        }
-        reachability.whenUnreachable = { [weak self] _ in
-            self?.stompLog(type: .info, message: "Network IS NOT reachable")
-            self?.hostIsReachabile = false
+        if let reachability = try? Reachability(queueQoS: .utility, targetQueue: DispatchQueue(label: "swiftStomp.reachability"), notificationQueue: .global()) {
+            reachability.whenReachable = { [weak self] _ in
+                self?.stompLog(type: .info, message: "Network IS reachable")
+                self?.hostIsReachabile = true
+            }
+            reachability.whenUnreachable = { [weak self] _ in
+                self?.stompLog(type: .info, message: "Network IS NOT reachable")
+                self?.hostIsReachabile = false
+            }
+            self.reachability = reachability
+        } else {
+            self.stompLog(type: .info, message: "Unable to create Reachability")
         }
     }
 }
@@ -145,7 +169,9 @@ public class SwiftStomp{
 /// Public Operating functions
 public extension SwiftStomp{
     func connect(timeout : TimeInterval = 5, acceptVersion : String = "1.1,1.2", autoReconnect : Bool = false){
-        
+
+        self.stompLog(type: .info, message: "Connecting...  autoReconnect: \(autoReconnect)")
+
         self.autoReconnect = autoReconnect
 
         //** If socket is connected now, just needs to connect to the Stomp
@@ -153,12 +179,12 @@ public extension SwiftStomp{
             self.stompConnect()
             return
         }
-        
+
         var urlRequest = URLRequest(url: self.host)
-        
+
         //** Accept Version
         self.acceptVersion = acceptVersion
-        
+
         //** Time interval
         urlRequest.timeoutInterval = timeout
 
@@ -168,77 +194,73 @@ public extension SwiftStomp{
             }
         }
 
-        //** Connect
-        self.socket = WebSocket(request: urlRequest)
-        
-        if let callbackQueue = self.callbacksThread{
-            self.socket.callbackQueue = callbackQueue
-        }
-        
+        self.webSocketTask = urlSession?.webSocketTask(with: urlRequest)
+        self.webSocketTask?.resume()
+
+        listen()
+
         self.status = .connecting
-        
-        self.socket.delegate = self
-        self.socket.connect()
     }
-    
+
     func disconnect(force : Bool = false){
-        
+
+        self.autoReconnect = false
         self.disableAutoPing()
         self.invalidateConnector()
-        
+
         if !force{ //< Send disconnect first over STOMP
             self.stompDisconnect()
         } else { //< Disconnect socket directly! (Not recommended until you have to do it!)
-            self.socket.forceDisconnect()
+            handleDisconnect()
         }
     }
-    
+
     func subscribe(to destination : String, mode : StompAckMode = .auto, headers : [String : String]? = nil){
         var headersToSend = StompHeaderBuilder
             .add(key: .destination, value: destination)
             .add(key: .id, value: destination)
             .add(key: .ack, value: mode.rawValue)
             .get
-        
+
         //** Append extra headers
         headers?.forEach({ hEntry in
             headersToSend[hEntry.key] = hEntry.value
         })
-        
+
         self.sendFrame(frame: StompFrame(name: .subscribe, headers: headersToSend))
     }
-    
+
     func unsubscribe(from destination : String, mode : StompAckMode = .auto, headers : [String : String]? = nil){
         var headersToSend = StompHeaderBuilder
             .add(key: .id, value: destination)
             .get
-        
+
         //** Append extra headers
         headers?.forEach({ hEntry in
             headersToSend[hEntry.key] = hEntry.value
         })
-        
+
         self.sendFrame(frame: StompFrame(name: .unsubscribe, headers: headersToSend))
     }
-    
+
     func send(body : String, to : String, receiptId : String? = nil, headers : [String : String]? = nil){
         let headers = prepareHeadersForSend(to: to, receiptId: receiptId, headers: headers)
-        
+
         self.sendFrame(frame: StompFrame(name: .send, headers: headers, stringBody: body))
     }
-    
+
     func send(body : Data, to : String, receiptId : String? = nil, headers : [String : String]? = nil){
         let headers = prepareHeadersForSend(to: to, receiptId: receiptId, headers: headers)
-        
+
         self.sendFrame(frame: StompFrame(name: .send, headers: headers, dataBody: body))
     }
-    
+
     func send <T : Encodable> (body : T, to : String, receiptId : String? = nil, headers : [String : String]? = nil, jsonDateEncodingStrategy : JSONEncoder.DateEncodingStrategy = .iso8601){
         let headers = prepareHeadersForSend(to: to, receiptId: receiptId, headers: headers)
-        
+
         self.sendFrame(frame: StompFrame(name: .send, headers: headers, encodableBody: body, jsonDateEncodingStrategy: jsonDateEncodingStrategy))
     }
-    
+
     func ack(messageId : String, transaction : String? = nil){
         let headerBuilder = StompHeaderBuilder
             .add(key: .id, value: messageId)
@@ -246,12 +268,12 @@ public extension SwiftStomp{
         if let transaction = transaction{
             _ = headerBuilder.add(key: .transaction, value: transaction)
         }
-        
+
         let headers = headerBuilder.get
-        
+
         self.sendFrame(frame: StompFrame(name: .ack, headers: headers))
     }
-    
+
     func nack(messageId : String, transaction : String? = nil){
         let headerBuilder = StompHeaderBuilder
             .add(key: .id, value: messageId)
@@ -259,169 +281,183 @@ public extension SwiftStomp{
         if let transaction = transaction{
             _ = headerBuilder.add(key: .transaction, value: transaction)
         }
-        
+
         let headers = headerBuilder.get
-        
+
         self.sendFrame(frame: StompFrame(name: .nack, headers: headers))
     }
-    
+
     func begin(transactionName : String){
         let headers = StompHeaderBuilder
             .add(key: .transaction, value: transactionName)
             .get
-        
+
         self.sendFrame(frame: StompFrame(name: .begin, headers: headers))
     }
-    
+
     func commit(transactionName : String){
         let headers = StompHeaderBuilder
             .add(key: .transaction, value: transactionName)
             .get
-        
+
         self.sendFrame(frame: StompFrame(name: .commit, headers: headers))
     }
-    
+
     func abort(transactionName : String){
         let headers = StompHeaderBuilder
             .add(key: .transaction, value: transactionName)
             .get
-        
+
         self.sendFrame(frame: StompFrame(name: .abort, headers: headers))
     }
-    
-    
+
+
     /// Send ping command to keep connection alive
     /// - Parameters:
     ///   - data: Date to send over Web socket
     ///   - completion: Completion block
     func ping(data: Data = Data(), completion: (() -> Void)? = nil) {
-        
+
         //** Check socket status
-        if self.status != .fullyConnected && self.status != .socketConnected{
+        guard let webSocketTask, self.status == .fullyConnected || self.status == .socketConnected else {
             self.stompLog(type: .info, message: "Stomp: Unable to send `ping`. Socket is not connected!")
             return
         }
-        
-        self.socket.write(ping: data, completion: completion)
-        
+
+        webSocketTask.sendPing() { _ in
+            completion?()
+        }
+
         self.stompLog(type: .info, message: "Stomp: Ping sent!")
-        
+
         //** Reset ping timer
         self.resetPingTimer()
     }
-    
-    
+
+
     /// Enable auto ping command to ensure connection will keep alive and prevent connection to stay idle
     /// - Notice: Please be care if you used `disconnect`, you have to re-enable the timer again.
     /// - Parameter pingInterval: Ping command send interval
     func enableAutoPing(pingInterval: TimeInterval = 10){
         self.pingInterval = pingInterval
         self.autoPingEnabled = true
-        
+
         //** Reset ping timer
         self.resetPingTimer()
     }
-    
-    
+
+
     /// Disable auto ping function
     func disableAutoPing(){
         self.autoPingEnabled = false
         self.pingTimer?.invalidate()
     }
-    
+
 }
 
 /// Helper functions
 fileprivate extension SwiftStomp{
     func stompLog(type : StompLogType, message : String){
-        if !self.enableLogging { return }
+        guard enableLogging else { return }
+
         let formatter = DateFormatter()
         formatter.dateFormat = "yyyy-MM-dd HH:mm:ss"
 
-        print("\(formatter.string(from: Date())) SwiftStomp [\(type.rawValue)]:\t \(message)")
+        let timestamp = formatter.string(from: Date())
+        os_log(type == .info ? .info : .error, "%s SwiftStomp [%s]: %s", timestamp, type.rawValue, message)
     }
-    
+
     func prepareHeadersForSend(to : String, receiptId : String? = nil, headers : [String : String]? = nil) -> [String : String]{
-        
+
         let headerBuilder = StompHeaderBuilder
         .add(key: .destination, value: to)
-        
+
         if let receiptId = receiptId{
             _ = headerBuilder.add(key: .receipt, value: receiptId)
         }
-        
+
         var headersToSend = headerBuilder.get
-        
+
         //** Append user headers
         if let headers = headers{
             for (hKey, hVal) in headers{
                 headersToSend[hKey] = hVal
             }
         }
-        
+
         return headersToSend
     }
-    
+
     func scheduleConnector(){
+        self.stompLog(type: .info, message: "Scheduling connector")
+
         if let scheduler = self.reconnectScheduler, scheduler.isValid{
             scheduler.invalidate()
+            reconnectScheduler = nil
         }
 
-        try? self.reachability.startNotifier()
+        try? self.reachability?.startNotifier()
 
-        self.reconnectScheduler = Timer.scheduledTimer(withTimeInterval: 3, repeats: true, block: { [weak self] (timer) in
-            guard let self = self else {
-                return
-            }
-            if !self.hostIsReachabile{
-                self.stompLog(type: .info, message: "Network is not reachable. Ignore connecting!")
-                return
-            }
+        DispatchQueue.main.async { [weak self] in
+            self?.reconnectScheduler = Timer.scheduledTimer(withTimeInterval: 3, repeats: true){ [weak self] timer in
+                guard let self = self else {
+                    return
+                }
 
-            self.connect(autoReconnect: self.autoReconnect)
-        })
+                self.stompLog(type: .info, message: "Reconnect scheduler running")
+
+                if !self.hostIsReachabile{
+                    self.stompLog(type: .info, message: "Network is not reachable. Ignore connecting!")
+                    return
+                }
+
+                self.connect(autoReconnect: self.autoReconnect)
+            }
+        }
     }
-    
+
     func invalidateConnector(){
+        self.stompLog(type: .info, message: "Invalidating connector")
+
         if let connector = self.reconnectScheduler, connector.isValid{
             connector.invalidate()
         }
 
-        self.reachability.stopNotifier()
+        self.reachability?.stopNotifier()
     }
-    
+
 }
 
 /// Back-Operating functions
 fileprivate extension SwiftStomp{
     func stompConnect(){
-        
+
         //** Add headers
         var headers = StompHeaderBuilder
             .add(key: .acceptVersion, value: self.acceptVersion)
             .get
-        
+
         //** Append connection headers
         if let stompConnectionHeaders = self.stompConnectionHeaders{
             for (hKey, hVal) in stompConnectionHeaders{
                 headers[hKey] = hVal
             }
         }
-        
-            
-        
+
+
+
         self.sendFrame(frame: StompFrame(name: .connect, headers: headers))
     }
-    
+
     func stompDisconnect(){
         //** Add headers
         let headers = StompHeaderBuilder
             .add(key: .receipt, value: "disconnect/safe")
             .get
-        
+
         self.sendFrame(frame: StompFrame(name: .disconnect, headers: headers))
     }
-    
+
     func processReceivedSocketText(text : String){
         var frame : StompFrame<StompResponseFrame>
 
@@ -432,62 +468,85 @@ fileprivate extension SwiftStomp{
             stompLog(type: .stompError, message: "Process frame error: \(ex.localizedDescription)")
             return
         }
-        
+
         //** Dispatch STOMP frame
 
         switch frame.name {
         case .message:
             stompLog(type: .info, message: "Stomp: Message received: \(String(describing: frame.body))")
-            
+
             let messageId = frame.getCommonHeader(.messageId) ?? ""
             let destination = frame.getCommonHeader(.destination) ?? ""
-            
-            self.delegate?.onMessageReceived(swiftStomp: self, message: frame.body, messageId: messageId, destination: destination, headers: frame.headers)
-            
+
+            callbacksThread.async { [weak self] in
+                guard let self else { return }
+                self.delegate?.onMessageReceived(swiftStomp: self, message: frame.body, messageId: messageId, destination: destination, headers: frame.headers)
+            }
+
         case .receipt:
             guard let receiptId = frame.getCommonHeader(.receiptId) else {
                 stompLog(type: .stompError, message: "Receipt message received without `receipt-id` header: \(text)")
                 return
             }
-            
-            
+
+
             stompLog(type: .info, message: "Receipt received: \(receiptId)")
-            
-            self.delegate?.onReceipt(swiftStomp: self, receiptId: receiptId)
-            
+
+            callbacksThread.async { [weak self] in
+                guard let self else { return }
+                self.delegate?.onReceipt(swiftStomp: self, receiptId: receiptId)
+            }
+
             if receiptId == "disconnect/safe"{
                 self.status = .socketConnected
-                
-                self.delegate?.onDisconnect(swiftStomp: self, disconnectType: .fromStomp)
-                self.socket.disconnect()
+
+                callbacksThread.async { [weak self] in
+                    guard let self else { return }
+                    self.delegate?.onDisconnect(swiftStomp: self, disconnectType: .fromStomp)
+                }
+
+                self.webSocketTask?.cancel(with: .goingAway, reason: nil)
+                self.webSocketTask = nil
             }
 
         case .error:
             self.status = .socketConnected
-            
+
             guard let briefDescription = frame.getCommonHeader(.message) else {
                 stompLog(type: .stompError, message: "Stomp error frame received without `message` header: \(text)")
                 return
             }
-            
+
             let fullDescription = frame.body as? String
             let receiptId = frame.getCommonHeader(.receiptId)
-            
+
             stompLog(type: .stompError, message: briefDescription)
-            
-            self.delegate?.onError(swiftStomp: self, briefDescription: briefDescription, fullDescription: fullDescription, receiptId: receiptId, type: .fromStomp)
+
+            callbacksThread.async { [weak self] in
+                guard let self else { return }
+                self.delegate?.onError(swiftStomp: self, briefDescription: briefDescription, fullDescription: fullDescription, receiptId: receiptId, type: .fromStomp)
+            }
+
         case .connected:
             self.status = .fullyConnected
-            
+
             stompLog(type: .info, message: "Stomp: Connected")
-            
-            self.delegate?.onConnect(swiftStomp: self, connectType: .toStomp)
+
+            callbacksThread.async { [weak self] in
+                guard let self else { return }
+                self.delegate?.onConnect(swiftStomp: self, connectType: .toStomp)
+            }
         default:
             stompLog(type: .info, message: "Stomp: Un-Processable content: \(text)")
         }
     }
-    
+
     func sendFrame(frame : StompFrame<StompRequestFrame>, completion : (() -> ())? = nil){
+        guard let webSocketTask else {
+            stompLog(type: .info, message: "Unable to send frame \(frame.name.rawValue): WebSocket is not connected!")
+            return
+        }
+
         switch self.status {
         case .socketConnected:
             if frame.name != .connect{
@@ -500,123 +559,150 @@ fileprivate extension SwiftStomp{
         default:
             break
         }
-            
+
         let rawFrameToSend = frame.serialize()
-        
+
         stompLog(type: .info, message: "Stomp: Sending...\n\(rawFrameToSend)\n")
-        
-        self.socket.write(string: rawFrameToSend, completion: completion)
-        
+
+        webSocketTask.send(.string(rawFrameToSend)) { error in
+            if let error = error {
+                self.stompLog(type: .stompError, message: "Error sending frame: \(error)")
+            }
+
+            completion?()
+        }
+
         //** Reset ping timer
         self.resetPingTimer()
     }
-    
+
     func resetPingTimer(){
         if !autoPingEnabled{
             return
         }
-        
-        //** Invalidate if timer is valid
-        if let t = self.pingTimer, t.isValid{
-            t.invalidate()
+
+        DispatchQueue.main.async { [weak self] in
+            guard let self else { return }
+
+            //** Invalidate if timer is valid
+            if let t = self.pingTimer, t.isValid{
+                t.invalidate()
+            }
+
+            //** Schedule the ping timer
+            self.pingTimer = Timer.scheduledTimer(withTimeInterval: self.pingInterval, repeats: true) { [weak self] _ in
+                self?.ping()
+            }
         }
-        
-        //** Schedule the ping timer
-        self.pingTimer = Timer.scheduledTimer(withTimeInterval: self.pingInterval, repeats: true, block: { [weak self] _ in
-            self?.ping()
-        })
     }
 }
 
 /// Web socket delegate
-extension SwiftStomp : WebSocketDelegate{
-    public func didReceive(event: WebSocketEvent, client: WebSocketClient) {
-        switch event {
-        case .connected(let headers):
-            self.status = .socketConnected
-            
-            self.invalidateConnector()
-            
-            stompLog(type: .info, message: "Scoket: connected: \(headers)")
-            
-            self.delegate?.onConnect(swiftStomp: self, connectType: .toSocketEndpoint)
-            
-            self.stompConnect()
-        case .disconnected(let reason, let code):
-            
-            stompLog(type: .info, message: "Socket: Disconnected: \(reason) with code: \(code)")
-            
-            self.delegate?.onDisconnect(swiftStomp: self, disconnectType: .fromSocket)
-            
-            //** Disable auto ping
-            self.disableAutoPing()
-            
-        case .text(let string):
-            stompLog(type: .info, message: "Socket: Received text")
-            
-            self.processReceivedSocketText(text: string)
-        case .binary(let data):
-            stompLog(type: .info, message: "Socket: Received data: \(data.count)")
-        case .ping(let data):
-            stompLog(type: .info, message: "Socket: Ping data with length \(String(describing: data?.count))")
-            
-        case .pong(let data):
-            stompLog(type: .info, message: "Socket: Pong data with length \(String(describing: data?.count))")
-            
-        case .viabilityChanged(let viability):
-            stompLog(type: .info, message: "Socket: Viability changed: \(viability)")
-            self.delegate?.onSocketEvent(eventName: "viabilityChangedTo\(viability)", description: "Socket viability changed")
-            
-        case .reconnectSuggested(let suggested):
-            stompLog(type: .info, message: "Socket: Reconnect suggested: \(suggested)")
-            
-            self.delegate?.onSocketEvent(eventName: "reconnectSuggested", description: "Socket Reconnect suggested")
+extension SwiftStomp {
+    private func listen() {
+        self.stompLog(type: .info, message: "Listening.")
+        webSocketTask?.receive { [weak self] result in
+            switch result {
+            case .failure(let error):
+                self?.stompLog(type: .socketError, message: "Socket listen: Error: \(error)")
 
-            if suggested{
-                self.connect()
-            }
-        case .cancelled:
-            self.status = .socketDisconnected
+                self?.callbacksThread.async { [weak self] in
+                    guard let self else { return }
+                    self.delegate?.onError(swiftStomp: self, briefDescription: "Stomp Error", fullDescription: error.localizedDescription, receiptId: nil, type: .fromStomp)
+                }
 
-            stompLog(type: .info, message: "Socket: Cancelled")
-            
-            self.delegate?.onSocketEvent(eventName: "cancelled", description: "Socket cancelled")
+            case .success(let message):
+                switch message {
+                case .string(let text):
+                    self?.stompLog(type: .info, message: "Socket: Received text")
+                    self?.processReceivedSocketText(text: text)
 
-            if self.autoReconnect{
-                self.scheduleConnector()
+                case .data(let data):
+                    self?.stompLog(type: .info, message: "Socket: Received data: \(data.count)")
+
+                default:
+                    break
+                }
+
+                // Keep listening
+                self?.listen()
             }
-        case .error(let error):
-            self.status = .socketDisconnected
-            
-            stompLog(type: .socketError, message: "Socket: Error: \(error.debugDescription)")
-            self.delegate?.onError(swiftStomp: self, briefDescription: "Socket Error", fullDescription: error?.localizedDescription, receiptId: nil, type: .fromSocket)
-            
-            if self.autoReconnect{
-                self.scheduleConnector()
-            }
-        case .peerClosed:
-            stompLog(type: .info, message: "Socket: Peer closed")
-        @unknown default:
-            stompLog(type: .info, message: "Socket: Unexpected event kind: \(String(describing: event))")
         }
     }
-    
+}
+
+extension SwiftStomp: URLSessionWebSocketDelegate {
+
+    public func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didOpenWithProtocol protocol: String?) {
+        let p = `protocol` ?? ""
+
+        self.status = .socketConnected
+        self.invalidateConnector()
+
+        stompLog(type: .info, message: "Socket: connected, protocol: \(p)")
+
+        callbacksThread.async { [weak self] in
+            guard let self else { return }
+            self.delegate?.onConnect(swiftStomp: self, connectType: .toSocketEndpoint)
+        }
+
+        self.stompConnect()
+    }
+
+    public func urlSession(_ session: URLSession, webSocketTask: URLSessionWebSocketTask, didCloseWith closeCode: URLSessionWebSocketTask.CloseCode, reason: Data?) {
+        var r = ""
+        if let d = reason {
+            r = String(data: d, encoding: .utf8) ?? ""
+        }
+
+        stompLog(type: .info, message: "Socket: Disconnected: \(r) with code: \(closeCode.rawValue)")
+
+        handleDisconnect()
+    }
+
+    public func urlSession(_ session: URLSession, task: URLSessionTask, didCompleteWithError error: Error?) {
+        stompLog(type: .socketError, message: "Socket: Error: \(error.debugDescription)")
+
+        handleDisconnect()
+
+        callbacksThread.async { [weak self] in
+            guard let self else { return }
+            self.delegate?.onError(swiftStomp: self, briefDescription: "Socket Error", fullDescription: error?.localizedDescription, receiptId: nil, type: .fromSocket)
+        }
+    }
+
+    private func handleDisconnect() {
+        pingTimer?.invalidate()
+        self.invalidateConnector()
+
+        self.webSocketTask?.cancel(with: .goingAway, reason: nil)
+        self.webSocketTask = nil
+
+        self.status = .socketDisconnected
+
+        callbacksThread.async { [weak self] in
+            guard let self else { return }
+            self.delegate?.onDisconnect(swiftStomp: self, disconnectType: .fromSocket)
+        }
+
+        if self.autoReconnect{
+            self.scheduleConnector()
+        }
+    }
 }
 
 // MARK: - SwiftStomp delegate
-public protocol SwiftStompDelegate{
-    
+public protocol SwiftStompDelegate: AnyObject{
+
     func onConnect(swiftStomp : SwiftStomp, connectType : StompConnectType)
-    
+
     func onDisconnect(swiftStomp : SwiftStomp, disconnectType : StompDisconnectType)
-    
+
     func onMessageReceived(swiftStomp : SwiftStomp, message : Any?, messageId : String, destination : String, headers : [String : String])
-    
+
     func onReceipt(swiftStomp : SwiftStomp, receiptId : String)
-    
+
     func onError(swiftStomp : SwiftStomp, briefDescription : String, fullDescription : String?, receiptId : String?, type : StompErrorType)
-    
-    func onSocketEvent(eventName : String, description : String)
 }
 
 // MARK: - Stomp Frame Class
@@ -624,54 +710,51 @@ fileprivate class StompFrame<T : RawRepresentable> where T.RawValue == String{
     var name : T!
     var headers = [String : String]()
     var body : Any?
-    
+
     init (name : T, headers : [String : String] = [:]){
         self.name = name
         self.headers = headers
     }
-    
+
     convenience init <X : Encodable>(name : T, headers : [String : String] = [:], encodableBody : X, jsonDateEncodingStrategy : JSONEncoder.DateEncodingStrategy = .iso8601){
         self.init(name: name, headers: headers)
-        
+
         let jsonEncoder = JSONEncoder()
         jsonEncoder.dateEncodingStrategy = jsonDateEncodingStrategy
-        
+
         if let jsonData = try? jsonEncoder.encode(encodableBody){
             self.body = String(data: jsonData, encoding: .utf8)
             self.headers[StompCommonHeader.contentType.rawValue] = "application/json;charset=UTF-8"
         }
     }
-    
+
     convenience init(name : T, headers : [String : String] = [:], stringBody : String){
         self.init(name: name, headers: headers)
-        
+
         self.body = stringBody
         if self.headers[StompCommonHeader.contentType.rawValue] == nil{
             self.headers[StompCommonHeader.contentType.rawValue] = "text/plain"
         }
-        
-        
-        
     }
-    
+
     convenience init(name : T, headers : [String : String] = [:], dataBody : Data){
         self.init(name: name, headers: headers)
-        
+
         self.body = dataBody
     }
-    
+
     init(withSerializedString frame : String) throws{
         try deserialize(frame: frame)
     }
-    
+
     func serialize() -> String{
         var frame = name.rawValue + "\n"
-        
+
         //** Headers
         for (hKey, hVal) in headers{
             frame += "\(hKey):\(hVal)\n"
         }
-        
+
         //** Body
         if body != nil{
             if let stringBody = body as? String{
@@ -683,21 +766,21 @@ fileprivate class StompFrame<T : RawRepresentable> where T.RawValue == String{
         } else {
             frame += "\n"
         }
-        
+
         //** Add NULL char
         frame += NULL_CHAR
-        
+
         return frame
     }
-    
+
     func deserialize(frame : String) throws{
         var lines = frame.components(separatedBy: "\n")
-        
+
         //** Remove first if was empty string
         if let firstLine = lines.first, firstLine.isEmpty {
             lines.removeFirst()
         }
-        
+
         //** Parse Command
         if let command = StompRequestFrame(rawValue: lines.first ?? ""){
             self.name = (command as! T)
@@ -706,20 +789,20 @@ fileprivate class StompFrame<T : RawRepresentable> where T.RawValue == String{
         } else {
             throw InvalidStompCommandError()
         }
-        
+
         //** Remove Command
         lines.removeFirst()
-        
+
         //** Parse Headers
         while let line = lines.first, !line.isEmpty {
             let headerParts = line.components(separatedBy: ":")
-            
+
             if headerParts.count != 2{
                 break
             }
-            
+
             self.headers[headerParts[0].trimmingCharacters(in: .whitespacesAndNewlines)] = headerParts[1].trimmingCharacters(in: .whitespacesAndNewlines)
-            
+
             lines.removeFirst()
         }
 
@@ -730,18 +813,18 @@ fileprivate class StompFrame<T : RawRepresentable> where T.RawValue == String{
 
         //** Parse body
         var body = lines.joined(separator: "\n")
-        
+
         if body.hasSuffix("\0"){
             body = body.replacingOccurrences(of: "\0", with: "")
         }
-        
+
         if let data = Data(base64Encoded: body){
             self.body = data
         } else {
             self.body = body
         }
     }
-    
+
     func getCommonHeader(_ header : StompCommonHeader) -> String?{
         return self.headers[header.rawValue]
     }
@@ -750,21 +833,21 @@ fileprivate class StompFrame<T : RawRepresentable> where T.RawValue == String{
 // MARK: - Header builder
 public class StompHeaderBuilder{
     private var headers = [String : String]()
-    
+
     static func add(key : StompCommonHeader, value : Any) -> StompHeaderBuilder{
         return StompHeaderBuilder(key: key.rawValue, value: value)
     }
-    
+
     private init(key : String, value : Any){
         self.headers[key] = "\(value)"
     }
-    
+
     func add(key : StompCommonHeader, value : Any) -> StompHeaderBuilder{
         self.headers[key.rawValue] = "\(value)"
-        
+
         return self
     }
-    
+
     var get : [String : String]{
         return self.headers
     }
@@ -772,7 +855,7 @@ public class StompHeaderBuilder{
 
 // MARK: - Errors
 public class InvalidStompCommandError : Error{
-    
+
     var localizedDescription: String {
         return "Invalid STOMP command"
     }

--- a/SwiftStomp/Classes/SwiftStomp.swift
+++ b/SwiftStomp/Classes/SwiftStomp.swift
@@ -694,7 +694,7 @@ fileprivate class StompFrame<T : RawRepresentable> where T.RawValue == String{
         var lines = frame.components(separatedBy: "\n")
         
         //** Remove first if was empty string
-        if lines.first == ""{
+        if let firstLine = lines.first, firstLine.isEmpty {
             lines.removeFirst()
         }
         
@@ -707,10 +707,11 @@ fileprivate class StompFrame<T : RawRepresentable> where T.RawValue == String{
             throw InvalidStompCommandError()
         }
         
+        //** Remove Command
         lines.removeFirst()
         
         //** Parse Headers
-        while let line = lines.first, line != ""{
+        while let line = lines.first, !line.isEmpty {
             let headerParts = line.components(separatedBy: ":")
             
             if headerParts.count != 2{
@@ -721,7 +722,12 @@ fileprivate class StompFrame<T : RawRepresentable> where T.RawValue == String{
             
             lines.removeFirst()
         }
-        
+
+        //** Remove the blank line between the headers and body
+        if let firstLine = lines.first, firstLine.isEmpty {
+            lines.removeFirst()
+        }
+
         //** Parse body
         var body = lines.joined(separator: "\n")
         


### PR DESCRIPTION
The starscream library doesn't correctly report an initial connection failure to the SwiftStomp when using the default TCPTransport.swift transport library, and despite there being two pending PRs https://github.com/daltoniam/Starscream/pull/904 and https://github.com/daltoniam/Starscream/pull/821 which both attempt to address the issue neither has been merged for 3 and 4 years each respectively. Hopes of this being resolved any time soon are not high.

This makes use of SwiftStomp in a production environment where connectivity needs to be ensured with adequate retries etc impossible.

The alternative if running on iOS 13+ is to use the NativeTransport.swift library internally, but that's just a very thin wrapper for Apple's URLSessionWebSocketTask, making the use of Starscream itself fairly redundant.

I've therefore removed the dependency on Starscream and have implemented the underlying WebSocket transport natively using URLSessionWebSocketTask. Surprise 🎉!

This is a big PR but makes the library much more robust, simplifies some things and removes the dependency on Starscream which seems to have always been problematic at best.

Cases that have been tested:
- Initial connection failure to the websocket with automatic reconnection enabled works
- Connection drops on an existing connection also result in automatic reconnection attempts
- Messages are being sent to topics correctly and subscription continues to work as-is
- SPM dependency works, cocopods dependencies are not tested as we don't use that
